### PR TITLE
xmm-modem: fix +XDNS parsing

### DIFF
--- a/packages/net/xmm-modem/root/etc/hotplug.d/iface/90-fibocom
+++ b/packages/net/xmm-modem/root/etc/hotplug.d/iface/90-fibocom
@@ -47,7 +47,7 @@ cellular_(){
                 IPADDR=$(echo "$DATA" | awk -F [,] '/^\+CGPADDR/{gsub("\"|\r",""); print $2}'| sed 's/[[:space:]]//g')
                 DNS0=$(echo "$DATA" | awk -F [,] '/^\+XDNS: 0/{gsub("\r|\"",""); print $2" "$3}' | sed 's/^[[:space:]]//g')
 		DNS1=$(echo "$DATA" | awk -F [,] '/^\+XDNS: 1/{gsub("\r|\"",""); print $2" "$3}' | sed 's/^[[:space:]]//g')
-		if [ $(echo $DNS0 | grep 0.0.0.0) ] ; then
+		if [ "$(echo $DNS0 | grep 0.0.0.0)" ] ; then
 			DNS=$DNS1
 		else
 			DNS=$DNS0


### PR DESCRIPTION
Without double quotes script working wrong and don't execute `grep 0.0.0.0`

> sh: 0.0.0.0: unknown operand

If `+XDNS: 0` is empty (0.0.0.0) it set 8.8.8.8/1.1.1.1 instead of using `+XDNS: 1`