### PR TITLE
Modify the reg value returned by the modeminfo script and Add the codes of Chinese telecom operators

### DIFF
--- a/packages/net/modeminfo/root/usr/share/modeminfo/mccmnc.dat
+++ b/packages/net/modeminfo/root/usr/share/modeminfo/mccmnc.dat
@@ -69,6 +69,14 @@
 43703;Fonex
 43705;MegaCom
 43709;O!
+46000;China Mobile
+46002;China Mobile
+46007;China Mobile
+46001;China Unicom
+46006;China Unicom
+46003;China Telecom
+46005;China Telecom
+46011;China Telecom
 50210;DiGi
 50211;TM
 50212;Maxis

--- a/packages/net/modeminfo/root/usr/share/modeminfo/scripts/modeminfo
+++ b/packages/net/modeminfo/root/usr/share/modeminfo/scripts/modeminfo
@@ -108,12 +108,15 @@ function get_cops() {
 
 # Get Registration data
 function get_reg_data(){
-	for CREG in "+CREG" "+CGREG" "+CEREG"; do
-		REGST=$(echo "$O" | awk -F[,] '/\'$CREG'/ {print $2}')
-		if [ "$REGST" ]; then
-			break
-		fi
-	done
+	var1=$(echo "$O" | awk -F[,] '/\+CREG/ {print $2}')
+	var2=$(echo "$O" | awk -F[,] '/\+CGREG/ {print $2}')
+	var3=$(echo "$O" | awk -F[,] '/\+CEREG/ {print $2}')
+
+	if [[ "$var2" -eq 1 || "$var3" -eq 1 ]]; then    
+		REGST=1
+	else
+		REGST=$var1   
+	fi    
 }
 
 function generic_data(){


### PR DESCRIPTION
Add the codes of the three major Chinese telecom operators and their corresponding English name
packages/net/modeminfo/root/usr/share/modeminfo/mccmnc.dat

Modify the reg value returned by the modeminfo script to resolve the issue of the operator displaying denied when using a pure data sim-card in luci-app-modeminfo.
packages/net/modeminfo/root/usr/share/modeminfo/scripts/modeminfo