### PR TITLE
luci-app-smstools3: fix utf-8

### DIFF
--- a/luci/applications/luci-app-smstools3/root/usr/bin/msg_control
+++ b/luci/applications/luci-app-smstools3/root/usr/bin/msg_control
@@ -12,11 +12,21 @@ function send_msg(){
 
 
 function recv_msg(){
-	from=$(echo "$1" | awk '/From:/{print $2}')
-	srecv=$(echo "$1" | awk '/Sent:/{gsub("Sent: ","");print $0}')
-	drecv=$(echo "$1" | awk '/Received:/{gsub("Received: ","");print $0}')
-	msg=$(echo "$1" |sed -e '1,/^$/ d'| sed 's/[]["]/\\&/g')
-	string="{ \"from\": \"$from\", \"srecv\": \"$srecv\", \"drecv\": \"$drecv\", \"content\": \"$msg\" },"
+    DECODE=$(uci -q get smstools3.@sms[0].decode_utf)
+
+    if [ "$DECODE" = "1" ]; then
+        from=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/From:/{print $2}')
+        srecv=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/Sent:/{gsub("Sent: ","");print $0}')
+        drecv=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/Received:/{gsub("Received: ","");print $0}')
+        msg=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | sed -e '1,/^$/ d'| sed 's/[]["]/\\&/g')
+        string="{ \"from\": \"$from\", \"srecv\": \"$srecv\", \"drecv\": \"$drecv\", \"content\": \"$msg\" },"
+    else
+        from=$(echo "$1" | awk '/From:/{print $2}')
+        srecv=$(echo "$1" | awk '/Sent:/{gsub("Sent: ","");print $0}')
+        drecv=$(echo "$1" | awk '/Received:/{gsub("Received: ","");print $0}')
+        msg=$(echo "$1" | sed -e '1,/^$/ d'| sed 's/[]["]/\\&/g')
+        string="{ \"from\": \"$from\", \"srecv\": \"$srecv\", \"drecv\": \"$drecv\", \"content\": \"$msg\" },"
+    fi
 }
 
 


### PR DESCRIPTION
```
function recv_msg(){
    DECODE=$(uci -q get smstools3.@sms[0].decode_utf)

    if [ "$DECODE" = "1" ]; then
        from=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/From:/{print $2}')
        srecv=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/Sent:/{gsub("Sent: ","");print $0}')
        drecv=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | awk '/Received:/{gsub("Received: ","");print $0}')
        msg=$(echo "$1" | iconv -f UTF-8 -t UTF-8 | sed -e '1,/^$/ d'| sed 's/[]["]/\\&/g')
        string="{ \"from\": \"$from\", \"srecv\": \"$srecv\", \"drecv\": \"$drecv\", \"content\": \"$msg\" },"
    else
        from=$(echo "$1" | awk '/From:/{print $2}')
        srecv=$(echo "$1" | awk '/Sent:/{gsub("Sent: ","");print $0}')
        drecv=$(echo "$1" | awk '/Received:/{gsub("Received: ","");print $0}')
        msg=$(echo "$1" | sed -e '1,/^$/ d'| sed 's/[]["]/\\&/g')
        string="{ \"from\": \"$from\", \"srecv\": \"$srecv\", \"drecv\": \"$drecv\", \"content\": \"$msg\" },"
    fi
}

```
Не знаю насколько понял логику - проверяем что к конфиге стоит галка преобразования в UTF-8, преобразуем.