### PR TITLE
feat: enable accel-ppp build by utilizing obsolete library

### DIFF
--- a/packages/libs/pcre/Config.in
+++ b/packages/libs/pcre/Config.in
@@ -1,0 +1,11 @@
+config PCRE_JIT_ENABLED
+	bool
+	depends on PACKAGE_libpcre && (arm || i386 || i686 || x86_64 || mips || mipsel || powerpc || sparc)
+	default y if (arm || i686 || x86_64)
+	prompt "Enable JIT compiler support"
+	help
+		Enable JIT (Just-In-Time) compiler support.
+
+		Enabling this option can give an about 10x performance increase on JIT operations. It can be desireable for e.g. high performance Apache mod_rewrite or HA-Proxy reqrep operations.
+
+		However, JIT should _only_ be enabled on architectures that are supported. Enabling JIT on unsupported platforms will result in a compilation failure. A list of supported architectures can be found here: https://pcre.org/original/doc/html/pcrejit.html#SEC3 .

--- a/packages/libs/pcre/Makefile
+++ b/packages/libs/pcre/Makefile
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pcre
+PKG_VERSION:=8.45
+PKG_RELEASE:=5
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
+
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+PKG_CPE_ID:=cpe:/a:pcre:pcre
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:=\
+	CONFIG_PACKAGE_libpcrecpp \
+	CONFIG_PCRE_JIT_ENABLED
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/libpcre/default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=https://www.pcre.org/
+endef
+
+define Package/libpcre/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/libpcre
+  $(call Package/libpcre/default)
+  TITLE:=A Perl Compatible Regular Expression library
+endef
+
+define Package/libpcre16
+  $(call Package/libpcre/default)
+  TITLE:=A Perl Compatible Regular Expression library (16bit support)
+endef
+
+define Package/libpcre32
+  $(call Package/libpcre/default)
+  TITLE:=A Perl Compatible Regular Expression library (32bit support)
+endef
+
+define Package/libpcrecpp
+  $(call Package/libpcre/default)
+  TITLE:=C++ wrapper for Perl Compatible Regular Expression library
+  DEPENDS:=+libpcre +libstdcpp
+endef
+
+HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--enable-utf8 \
+	--enable-unicode-properties \
+	--enable-pcre16 \
+	--with-match-limit-recursion=16000 \
+	--enable-cpp \
+	--with-pic
+
+CONFIGURE_ARGS += \
+	--enable-utf8 \
+	--enable-unicode-properties \
+	--enable-pcre16 \
+	--enable-pcre32 \
+	$(if $(CONFIG_PCRE_JIT_ENABLED),--enable-jit,--disable-jit) \
+	--with-match-limit-recursion=16000 \
+	--$(if $(CONFIG_PACKAGE_libpcrecpp),en,dis)able-cpp \
+	--with-pic
+
+MAKE_FLAGS += \
+	CFLAGS="$(TARGET_CFLAGS)"
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pcre-config $(1)/usr/bin/
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(1)/usr/bin/pcre-config
+
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) $(STAGING_DIR)/usr/bin/pcre-config $(2)/bin
+
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pcre*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre*.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpcre*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libpcre/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre{,posix}.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre.so $(1)/usr/lib/
+endef
+
+define Package/libpcre16/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre16.so* $(1)/usr/lib/
+endef
+
+define Package/libpcre32/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre32.so* $(1)/usr/lib/
+endef
+
+define Package/libpcrecpp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcrecpp.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libpcre))
+$(eval $(call BuildPackage,libpcre16))
+$(eval $(call BuildPackage,libpcre32))
+$(eval $(call BuildPackage,libpcrecpp))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Upload pcre library from owrt 23.05 packages branch for use in 24.10 build (and forward)