### PR TITLE
Fix Quectel EM12

### DIFF
--- a/packages/net/modeminfo/root/usr/share/modeminfo/scripts/QUECTEL
+++ b/packages/net/modeminfo/root/usr/share/modeminfo/scripts/QUECTEL
@@ -12,7 +12,7 @@ function modem_data(){
 		        IMSI=$(echo "$O" | grep -A3 -i $FAMILY | tail -1)
 		        IMEI=$(echo "$O" | grep -A4 -i $FAMILY | tail -1)
 		;;
-                *EC21*|*EC25*|*EP06*|*EM160*)
+                *EC21*|*EC25*|*EP06*|*EM12*|*EM160*)
                         IMSI=$(echo "$O" | grep -A1 -i $FW | tail -1)
                         IMEI=$(echo "$O" | grep -A1 -i $ICCID | tail -1)
 		;;
@@ -85,7 +85,7 @@ function modem_data(){
 			CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {print $3}')
 			# Quectel EM1X modem temp sensors
 			if [ ! $(echo "$CHIPTEMP" | grep "^?[0-9]+$") ] || [ $CHIPTEMP -eq 255 ]; then
-				CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {gsub("\"",""); print $2}')
+				CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {gsub("\"",""); print $3}')
 			fi
 		;;
 	esac

--- a/packages/net/modeminfo/root/usr/share/modeminfo/scripts/QUECTEL
+++ b/packages/net/modeminfo/root/usr/share/modeminfo/scripts/QUECTEL
@@ -80,12 +80,13 @@ function modem_data(){
 		SINR=$ECIO
 	fi
 	case $MDL in
+		*EM12*) CHIPTEMP=$(echo "$O" | awk -F'[,\ ]' '/^\+QTEMP/ {gsub("\"",""); print $3}') ;;
 		*EM160*) CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP: \"cpu-usr\"/ {gsub("\"","");print $3}') ;;
 		*)
 			CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {print $3}')
 			# Quectel EM1X modem temp sensors
 			if [ ! $(echo "$CHIPTEMP" | grep "^?[0-9]+$") ] || [ $CHIPTEMP -eq 255 ]; then
-				CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {gsub("\"",""); print $3}')
+				CHIPTEMP=$(echo "$O" | awk -F[,\ ] '/^\+QTEMP/ {gsub("\"",""); print $2}')
 			fi
 		;;
 	esac


### PR DESCRIPTION
**Small fix for Quectel EM12 modem.**
- Changed IMEI data retrieval.
- Unique changes have been made to the Quectel EM12 modem temperature.

<img width="977" alt="440166563-0db914f5-a34e-45ff-a267-9d886d716859" src="https://github.com/user-attachments/assets/e47d0b62-5479-4abc-bdff-42c2b98bd8ca" />
